### PR TITLE
Remove square brackets around jira ticket ref

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -9,4 +9,4 @@
 
 ## Related JIRA issues
 
-* [ENG-0000]
+* ENG-0000


### PR DESCRIPTION
## Description
* Remove brackets around Jira reference

## Why
* github sometimes tries to transform these links
